### PR TITLE
widok miesieczny skonczony

### DIFF
--- a/index.html
+++ b/index.html
@@ -145,15 +145,7 @@
                 </tr>
                 </tbody>
             </table>
-            <div class="legend">
-                <div class="legend-item" id="legend-laboratorium">Laboratorium</div>
-                <div class="legend-item" id="legend-wyklad">Wykład</div>
-                <div class="legend-item" id="legend-lektorat">Lektorat</div>
-                <div class="legend-item" id="legend-audytorium">Audytorium</div>
-                <div class="legend-item" id="legend-projekt">Projekt</div>
-                <div class="legend-item" id="legend-konsultacje">Konsultacje</div>
-                <div class="legend-item" id="legend-wlasny-kafelek">Własny Kafelek</div>
-            </div>
+
 
             <div class="statistics" id="statistics">
                 <div class="statistics-item" id="statistics-laboratorium">


### PR DESCRIPTION
Widok miesieczny skonczony,
Naprawiono kolof kafelkow w widokach miesiecznych i zakresowych, aby pokolorwane byly tylko te kafelki w których sa lekcje,
tam gdzie nie ma lekcji juz nie bedzie sie wyswietlalo zadne info po najechaniu/klikienciu